### PR TITLE
we don't collect the IMEI ourselves

### DIFF
--- a/de.md
+++ b/de.md
@@ -281,4 +281,4 @@ Zur Geltendmachung eines Widerspruchs oder Widerrufs können Sie sich an unseren
 
 --
 
-_Stand der Datenschutzerklärung: 02.08.2018_
+_Stand der Datenschutzerklärung: 01.02.2019_

--- a/de.md
+++ b/de.md
@@ -71,7 +71,7 @@ Wir verwenden einen sicheren und vollständig verschlüsselten Analysedienst, de
 Neben den unter 7.g. beschriebenen Daten erheben wir die folgenden Daten, wenn Sie unsere App nutzen:
 
 - Nutzungsstatistiken der App, z. B. dazu, mit welchen Oberflächenelementen interagiert wird
-- Daten zu Ihrer App oder Ihrem Endgerät, z. B. Name des Gerätes, Hersteller, Modell, Betriebssystemversion, App-Version oder SDK-Version sowie Gerätenummer (IMEI)
+- Daten zu Ihrer App oder Ihrem Endgerät, z. B. Name des Gerätes, Hersteller, Modell, Betriebssystemversion sowie App-Version oder SDK-Version
 
 Die Ecosia App nutzt ggf. in anonymisierter bzw. pseudonymisierter Form Ihre Standortdaten, sofern Sie den Zugriff auf diese Daten auf Ihrem Gerät erlaubt haben. Wir nutzen die Standortdaten, um Ihnen ein besseres Benutzererlebnis im Zusammenhang mit Ecosia bieten oder relevantere Suchergebnisse oder Werbung für Sie bereitstellen zu können. Personenbezogene Daten, z. B. Name, Adresse oder Geburtsdatum, werden nicht erhoben, gespeichert oder übermittelt.
 

--- a/en.md
+++ b/en.md
@@ -67,7 +67,7 @@ We use a safe and fully encrypted analysis service, which we ourselves operate, 
 Additionally to the data described under 7.g. we collect the following data when you use our app:
 
  - Usage statistics of the app, e.g. which interface elements are interacted with
- - Data relating to your app or your end device, e.g. the name of the device, its manufacturer, model, operating system number, app number or SDK version and the device number (IMEI)
+ - Data relating to your app or your end device, e.g. the name of the device, its manufacturer, model, operating system number and app number or SDK version
 
 The Ecosia app may use your locational data in anonymized, respectively pseudonymized, form if you have allowed access to these data on your device. We use the locational data in order to give you a better Ecosia experience or to show more relevant search results or advertising to you. Personal data such as names, addresses or dates of birth will not be collected, stored or transmitted.
 

--- a/en.md
+++ b/en.md
@@ -279,4 +279,4 @@ To assert a refusal or a withdrawal of consent, please contact our Data Protecti
 
 ---
 
-_Data protection declaration version date: 02/08/2018
+_Data protection declaration version date: 01/02/2019_

--- a/fr.md
+++ b/fr.md
@@ -281,4 +281,4 @@ Pour faire valoir une opposition ou une révocation, vous pouvez contacter notre
 
 ---
 
-_Date de la déclaration sur la protection des données : 02/08/2018_
+_Date de la déclaration sur la protection des données : 01/02/2019_

--- a/fr.md
+++ b/fr.md
@@ -71,7 +71,7 @@ Nous utilisons un service d’analyse sécurisé et entièrement crypté que nou
 En plus des données décrites au point 7.g., nous collectons les données suivantes lorsque vous utilisez notre application :
 
 - Les statistiques d’utilisation de l’application, p. ex. quels éléments de l’interface sont en interaction 
-- Les données relatives à votre application ou à votre terminal, p. ex. le nom de l’appareil, son fabricant, son modèle, le numéro de son système d’exploitation, le numéro de l’application ou la version du SDK et le numéro de l’appareil (IMEI) 
+- Les données relatives à votre application ou à votre terminal, p. ex. le nom de l’appareil, son fabricant, son modèle, le numéro de son système d’exploitation et le numéro de l’application ou la version du SDK
 
 L’application Ecosia peut être amenée à utiliser vos données de géolocalisation sous une forme anonymisée, voire pseudonymisée, si vous avez autorisé l’accès à ces données sur votre appareil. Nous utilisons les données de géolocalisation pour vous fournir une meilleure expérience Ecosia ou pour montrer davantage de résultats de recherche ou de publicités pertinents. Des données à caractère personnel telles que les noms, adresses ou dates de naissance ne seront pas collectées, stockées ou transmises.
 


### PR DESCRIPTION
Turns out that we are not collecting the IMEI through our iOS and Android app ourselves. That is good we don't need that unique identifier but the policy stated wrongly that we do. Now fixed. This ID is still collected by hockeyapp for both apps and the facebook SDK for Android.